### PR TITLE
Update the apt::key call to be compatible with puppetlabs/apt 2.x release

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
-  repositories:
-    apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+  forge_modules:
+    apt: "puppetlabs/apt"
+    stdlib: "puppetlabs/stdlib"
   symlinks:
     puppetlabs_apt: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "rspec-puppet"
   gem "puppetlabs_spec_helper"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/rodjek/rspec-puppet.git
-  revision: 6ac97993fa972a15851a73d55fe3d1c0a85172b5
-  specs:
-    rspec-puppet (1.0.1)
-      rspec
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -194,6 +187,8 @@ GEM
       rspec-core (>= 2.99.0.beta1)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-mocks (2.99.2)
+    rspec-puppet (2.1.0)
+      rspec
     serverspec (1.16.0)
       highline
       net-ssh
@@ -245,7 +240,7 @@ DEPENDENCIES
   puppet-blacksmith
   puppetlabs_spec_helper
   rake
-  rspec-puppet!
+  rspec-puppet
   travis
   travis-lint
   vagrant-wrapper

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,12 +28,14 @@ class puppetlabs_apt(
   }
 
   apt::source { 'puppetlabs':
-    location   => 'http://apt.puppetlabs.com/',
-    key        => '1054B7A24BD6EC30',
-    key_source => 'https://apt.puppetlabs.com/pubkey.gpg',
-    pin        => '550',
-    repos      => $repo_list,
-    release    => $release,
+    location => 'http://apt.puppetlabs.com/',
+    key      => {
+      id     => '1054B7A24BD6EC30',
+      source => 'https://apt.puppetlabs.com/pubkey.gpg'
+    },
+    pin      => '550',
+    repos    => $repo_list,
+    release  => $release,
   }
 
   package{ 'puppetlabs-release':


### PR DESCRIPTION
Also:
- Use the released rspec-puppet Gem
- Use forge releases instead of latest master for the puppet modules fixtures
