### PR TITLE
Update apt::source resource for newer apt module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,16 +37,19 @@ class puppetlabs_apt(
     }
   }
 
+
   apt::source { 'puppetlabs':
-    location   => 'http://apt.puppetlabs.com/',
-    key        => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
-    key_source => 'https://apt.puppetlabs.com/pubkey.gpg',
-    pin        => '550',
-    repos      => $repo_list,
-    release    => $_release,
+    location => 'http://apt.puppetlabs.com/',
+    repos    => $repo_list,
+    release  => $_release,
+    pin      => '550',
+    key      => {
+      'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+      'server' => 'pgp.mit.edu',
+    },
   }
 
-  package{ 'puppetlabs-release':
+  package { 'puppetlabs-release':
     ensure  => installed,
     require => Apt::Source['puppetlabs'],
   }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 2.0.1"
     }
   ],
   "operatingsystem_support": [
@@ -19,6 +19,7 @@
       "operatingsystemrelease": [
         "6",
         "7"
+        "8"
       ]
     },
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,7 +6,8 @@ shared_examples 'shared examples' do
   it { should contain_class('puppetlabs_apt') }
   it { should contain_package('puppetlabs-release') }
   it { should contain_apt__source('puppetlabs').with_location('http://apt.puppetlabs.com/') }
-  it { should contain_apt__source('puppetlabs').with_key('47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30') }
+  it { should contain_apt__source('puppetlabs').with_key({'id' => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+                                                          'server' => 'pgp.mit.edu'}) }
 end
 
 describe 'puppetlabs_apt' do


### PR DESCRIPTION
Use the newer syntax on the puppetlabs-apt module and bump the
dependencies.