### PR TITLE
Add Puppet 4 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 2.0.1"
+      "version_requirement": ">= 2.1.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -31,12 +31,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
- Bump puppetlabs/apt to minimum version which supports Puppet 4
- Remove deprecated pe field